### PR TITLE
Allow configuration of message format for displaying (html, text).

### DIFF
--- a/lib/logstash/outputs/hipchat.rb
+++ b/lib/logstash/outputs/hipchat.rb
@@ -29,6 +29,9 @@ class LogStash::Outputs::HipChat < LogStash::Outputs::Base
   # Message format to send, event tokens are usable here.
   config :format, :validate => :string, :default => "%{message}"
 
+  # Message format to display. Currently supported are "html" (default) and "text"
+  config :message_format, :validate => :string, :default => "html"
+
   public
   def register
     require "ftw"
@@ -50,6 +53,7 @@ class LogStash::Outputs::HipChat < LogStash::Outputs::Base
     hipchat_data['color']   = @color
     hipchat_data['notify']  = @trigger_notify ? "1" : "0"
     hipchat_data['message'] = event.sprintf(@format)
+    hipchat_data['message_format'] = @message_format
 
     @logger.debug("HipChat data", :hipchat_data => hipchat_data)
 


### PR DESCRIPTION
Hello,

i've added support for HipChat `message_format` attribute configuration in logstash configuration file. It is sometimes desired to send plain text instead of HTML which is default option.

Thank you for revising and integration.