### PR TITLE
Update this plugin to use the official hipchat gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# 2.0.0
+- Use hipchat official gem
+- support v2 version of the api and HipChat cloud server.
+- Added a few tests
+- more options of this plugin now support fieldref

--- a/logstash-output-hipchat.gemspec
+++ b/logstash-output-hipchat.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-hipchat'
-  s.version         = '1.0.0'
+  s.version         = '2.0.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "This output allows you to write events to Hipchat"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/logstash-output-hipchat.gemspec
+++ b/logstash-output-hipchat.gemspec
@@ -21,8 +21,8 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core", '>= 1.4.0', '< 2.0.0'
-
-  s.add_runtime_dependency 'ftw', ['~> 0.0.40']
+  s.add_runtime_dependency "logstash-codec-plain"
+  s.add_runtime_dependency "hipchat"
 
   s.add_development_dependency 'logstash-devutils'
 end

--- a/spec/outputs/hipchat_spec.rb
+++ b/spec/outputs/hipchat_spec.rb
@@ -1,1 +1,80 @@
-require "logstash/devutils/rspec/spec_helper"
+# encoding: utf-8
+require "logstash/outputs/hipchat"
+require "logstash/event"
+require_relative "../spec_helper"
+
+describe LogStash::Outputs::HipChat do
+  let(:token) { "secret" }
+  let(:message) { "foobar" }
+  let(:event) { LogStash::Event.new({ "message" => message }) }
+  let(:room_id) { "secret-lair" }
+  let(:from) { "computer" }
+  let(:trigger_notify) { true }
+  let(:color) { "yellow" }
+  let(:message_format) { "html" }
+  let(:options) {
+    { 
+      "token" => token,
+      "room_id" => room_id,
+      "from" => from,
+      "color" => color,
+      "trigger_notify" => trigger_notify
+    }
+  }
+  let(:hipchat) { double("hipchat") }
+  let(:output) { LogStash::Outputs::HipChat.new(options) }
+
+  before do
+    output.register
+  end
+
+  shared_examples "sending events" do
+    it "send the events" do
+      expect(hipchat).to receive(:send).with(from, message, :notify => trigger_notify, :color => color, :message_format => message_format)
+      output.receive(event)
+    end
+
+    context "String interpolation" do
+      let(:event) {
+        LogStash::Event.new({ "message" => message,
+                              "my_room" => room_id,
+                              "my_color" => color,
+                              "from_who" => from})
+      }
+
+      let(:options) {
+        super.merge({
+          "token" => "secret",
+          "room_id" => "%{my_room}",
+          "from" => "%{from_who}",
+          "color" => "%{my_color}",
+          "trigger_notify" => trigger_notify
+        })
+      }
+
+      it "applies string interpolation" do
+        expect(hipchat).to receive(:send).with(from, message, :notify => trigger_notify, :color => color, :message_format => message_format)
+        output.receive(event)
+      end
+    end
+  end
+
+  context "default host" do
+    before do
+      expect(HipChat::Client).to receive(:new).with(token, :api_version => "v2").and_return({ room_id => hipchat })
+    end
+
+    include_examples "sending events"
+  end
+
+  context "specified host" do
+    let(:host) { "local.dev" }
+    let(:options) { super.merge({ "host" => host }) }
+
+    before do
+      expect(HipChat::Client).to receive(:new).with(token, :api_version => "v2", :server_url => "https://#{host}").and_return({ room_id => hipchat })
+    end
+
+    include_examples "sending events"
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,2 @@
+# encoding: utf-8
+require "logstash/devutils/rspec/spec_helper"


### PR DESCRIPTION
- Do not use ftw anymore
- Dropped dependency on the http output
- Allow people to use the v2 api and hipchat's cloud offering

Fixes #7  #5 

Also includes suggestion from #4 #3