### PR TITLE
fix Issue #11

### DIFF
--- a/logstash-output-hipchat.gemspec
+++ b/logstash-output-hipchat.gemspec
@@ -22,7 +22,8 @@ Gem::Specification.new do |s|
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
   s.add_runtime_dependency "logstash-codec-plain"
-  s.add_runtime_dependency "hipchat"
+  s.add_runtime_dependency "hipchat", "= 1.5.4"
+  s.add_runtime_dependency "httparty", "= 0.14.0"
 
   s.add_development_dependency 'logstash-devutils'
 end


### PR DESCRIPTION
pin versions of httparty and hipchat depdencies to support running in logstash jruby (ruby 1.9). httparty and hipchat have since moved on (ruby > 2)

