### PR TITLE
Change  config type to  to prevent leaking in the debug logs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 4.0.5
+## 4.0.6
   - Change `token` config type to `password` to prevent leaking it in debug logs [#15](https://github.com/logstash-plugins/logstash-output-hipchat/pull/15)
 
 ## 4.0.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## 4.0.5
+  - Change `token` config type to `password` to prevent leaking it in debug logs [#15](https://github.com/logstash-plugins/logstash-output-hipchat/pull/15)
+
+## 4.0.5
   - Docs: Set the default_codec doc attribute.
 
 ## 4.0.4

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -40,7 +40,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-host>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-message_format>> |<<string,string>>, one of `["html", "text"]`|No
 | <<plugins-{type}s-{plugin}-room_id>> |<<string,string>>|Yes
-| <<plugins-{type}s-{plugin}-token>> |<<string,string>>|Yes
+| <<plugins-{type}s-{plugin}-token>> |<<password,password>>|Yes
 | <<plugins-{type}s-{plugin}-trigger_notify>> |<<boolean,boolean>>|No
 |=======================================================================
 
@@ -104,7 +104,7 @@ The ID or name of the room, support fieldref
 ===== `token` 
 
   * This is a required setting.
-  * Value type is <<string,string>>
+  * Value type is <<password,password>>
   * There is no default value for this setting.
 
 The HipChat authentication token.

--- a/lib/logstash/outputs/hipchat.rb
+++ b/lib/logstash/outputs/hipchat.rb
@@ -10,7 +10,7 @@ class LogStash::Outputs::HipChat < LogStash::Outputs::Base
   config_name "hipchat"
 
   # The HipChat authentication token.
-  config :token, :validate => :string, :required => true
+  config :token, :validate => :password, :required => true
 
   # The ID or name of the room, support fieldref
   config :room_id, :validate => :string, :required => true
@@ -42,9 +42,9 @@ class LogStash::Outputs::HipChat < LogStash::Outputs::Base
 
   def client
     @client ||= if @host.nil? || @host.empty? 
-                  HipChat::Client.new(@token, :api_version => "v2")
+                  HipChat::Client.new(@token.value, :api_version => "v2")
                 else
-                  HipChat::Client.new(@token, :api_version => "v2", :server_url => server_url)
+                  HipChat::Client.new(@token.value, :api_version => "v2", :server_url => server_url)
                 end
   end
 

--- a/logstash-output-hipchat.gemspec
+++ b/logstash-output-hipchat.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-hipchat'
-  s.version         = '4.0.5'
+  s.version         = '4.0.6'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "This output allows you to write events to Hipchat"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/outputs/hipchat_spec.rb
+++ b/spec/outputs/hipchat_spec.rb
@@ -77,4 +77,14 @@ describe LogStash::Outputs::HipChat do
 
     include_examples "sending events"
   end
+
+  describe "debugging `token`" do
+
+    it "should not show origin value" do
+      expect(output.logger).to receive(:debug).with('<password>')
+
+      output.register
+      output.logger.send(:debug, output.token.to_s)
+    end
+  end
 end

--- a/spec/outputs/hipchat_spec.rb
+++ b/spec/outputs/hipchat_spec.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
+require_relative "../spec_helper"
 require "logstash/outputs/hipchat"
 require "logstash/event"
-require_relative "../spec_helper"
 
 describe LogStash::Outputs::HipChat do
   let(:token) { "secret" }


### PR DESCRIPTION
When running Logstash with `--config.debug` option, we may see the `token` values. in the debug logs. This change changes `token` type to `password` to prevent leaking it in the debug logs.

- Closes #14 